### PR TITLE
Add Beeminder to the directory

### DIFF
--- a/_data/directory.yml
+++ b/_data/directory.yml
@@ -40,3 +40,9 @@
   description: "Empowering developers everywhere"
   join_date: 2013-02-06
   slug: bevry
+
+- name: Beeminder
+  url: https://www.beeminder.com
+  description: Goal-tracking with teeth
+  join_date: 2014-05-07
+  slug: beeminder


### PR DESCRIPTION
Other information requested at opencompany.org/join:
Daniel Reeves, CEO
Logos: http://expost.padm.us/blogo (no SVG yet)
Openness example: We show metrics, including revenue, publicly at beeminder.com/meta
