### PR TITLE
Simplify the pledge

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -1,5 +1,5 @@
 oci: "The Open Company Initiative"
-pledge: "We who belong to the Open Company Initiative pledge to create value through openness."
+pledge: "We who belong to the Open Company Initiative commit to openness as a defining element in how we create value."
 directory_header: "Member Companies"
 feed_title: "The Open Company Initiative blog"
 pages:

--- a/_i18n/en/about/index.md
+++ b/_i18n/en/about/index.md
@@ -1,5 +1,5 @@
-The Open Company Initiative (OCI) is a group of companies committed to creating
-value through openness.
+The Open Company Initiative (OCI) is a group of companies committed to openness
+as a defining element in how we create value.
 
 
 ### Our Vision

--- a/_i18n/en/home/teaser.html
+++ b/_i18n/en/home/teaser.html
@@ -1,1 +1,2 @@
-        Creating value through openness
+Companies committed to openness as a<br>
+defining element in how we create value


### PR DESCRIPTION
This changes the pledge from:

> maximize operational transparency and openness as a defining element in how we create value

to:

> create value through openness

The purpose of this change is to boil our message down to the essentials, shedding some jargon in the process. With this change we can focus our efforts around defining "openness." I envision a pattern library inspired by the [Responsive Patterns](http://bradfrost.github.io/this-is-responsive/patterns.html) site. This would replace the blog, as I believe we've discussed in the past.
