### PR TITLE
Adding Technical Machine

### DIFF
--- a/_data/directory.yml
+++ b/_data/directory.yml
@@ -64,3 +64,9 @@
   description: "Make the internet fun again. Create your own free web site."
   join_date: 2014-10-17
   slug: neocities
+  
+- name: Technical Machine
+  url: https://tessel.io/
+  description: Creating the Open Web of hardware.
+  join_date: 2014-12-4
+  slug: technical


### PR DESCRIPTION
Hi! I'm Director of Community at Technical Machine. We've considered ourselves an open company since we started, and I've written about it here: http://blog.technical.io/post/76637645290/transparency-keeping-an-open-company
I didn't realize until just now that there was an official "Open Company" group, and I'm glad to see it.
Our logo can be found here: https://www.dropbox.com/s/ypgc17h98j3zs24/tessel-logo.svg?dl=0

I suspect I'm missing something with this PR, so please let me know if I need to change anything.

Thanks,
Kelsey
