### PR TITLE
provide ruby version to fix the travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+rvm:
+  - 2.0.0
 script: bundle exec jekyll build
 branches:
   only:


### PR DESCRIPTION
The build currently errors out with:
Gem::InstallError: public_suffix requires Ruby version >= 2.0.