### PR TITLE
Change Gratipay to Liberapay

### DIFF
--- a/_i18n/en/about/index.md
+++ b/_i18n/en/about/index.md
@@ -35,7 +35,7 @@ learn from one another and further our vision.
 The OCI is housed at [The Saxifrage School](http://www.saxifrageschool.org/), a
 higher education laboratory working to lower costs, foster transparency,
 re-think the campus, and reconcile theory and practice. The Initiative is
-funded [on Gratipay](https://gratipay.com/OpenCompany/), and we communicate
+funded on Gratipay (now [Liberapay](https://liberapay.com)), and we communicate
 primarily [using
 GitHub](https://github.com/opencompany/www.opencompany.org/issues). Some of
 us can be found on the initiative's IRC channel on freenode: ##opencompany.
@@ -45,12 +45,7 @@ publicly available [here](/stats/).
 
 ### Funding
 
-The OCI is funded by pay-what-you-want membership dues, <a
-href="https://gratipay.com/OpenCompany/">via Gratipay</a>.
-
-<div class="gratipay-widget">
-    <script data-gratipay-username="OpenCompany" src="//grtp.co/v1.js"></script>
-</div>
+The OCI is funded by pay-what-you-want membership dues via [Liberapay](https://liberapay.com/opencompany/).
 
 
 ### Further Reading
@@ -62,4 +57,3 @@ href="https://gratipay.com/OpenCompany/">via Gratipay</a>.
   - <a href="/resources/whitepaper.pdf">A Whitepaper on Open Enterprise</a>
   - <a href="https://medium.com/the-saxifrage-school/1cc89b9de873">An Open School?</a>
   - <a href="http://theopencompany.net/pages/about-us">The Open [Products] Company</a>
-

--- a/_i18n/en/join/index.md
+++ b/_i18n/en/join/index.md
@@ -29,10 +29,4 @@ with the following information:
 
 ### Dues
 
-Membership dues are pay what you want, <a
-href="https://gratipay.com/OpenCompany/">via Gratipay</a>.
-
-<div class="gratipay-widget">
-    <script data-gratipay-username="OpenCompany" src="//grtp.co/v1.js"></script>
-</div>
-
+Membership dues are pay what you want via [Liberapay](https://liberapay.com/opencompany/).

--- a/_i18n/fr/about/index.md
+++ b/_i18n/fr/about/index.md
@@ -31,18 +31,13 @@ expériences et promouvoir notre vision.
 
 L'OCI est situé á [The Saxifrage School](http://www.saxifrageschool.org/), un laboratoire de
 l'éducation supérieure cherchant à réduire les coûts, favoriser la transparence, repenser le campus et
-concilier la théorie et la pratique. L'initiative est financée [sur
-Gratipay](https://gratipay.com/OpenCompany/), nous communiquons
+concilier la théorie et la pratique. L'initiative est financée sur Gratipay (aujourd'hui [Liberapay](https://liberapay.com/opencompany/)), nous communiquons
 principalement [en utilisant github](https://github.com/opencompany/www.opencompany.org/issues). Certains d'entre nous se retrouvent sur le canal IRC de l'initiative sur le réseau freenode: ##opencompany.
 
 
 ### Financement
 
-L'OCI est financé par les cotisations libre des membres, <a href="https://gratipay.com/OpenCompany/">via Gratipay </a>.
-
-<div class="gratipay-widget">
-    <script data-gratipay-username="OpenCompany" src="//grtp.co/v1.js"></script>
-</div>
+L'OCI est financé par les cotisations libre des membres via [Liberapay](https://liberapay.com/opencompany/).
 
 
 ### Pour aller plus loin
@@ -54,4 +49,3 @@ L'OCI est financé par les cotisations libre des membres, <a href="https://grati
   - <a href="/resources/whitepaper.pdf">A Whitepaper on Open Enterprise</a>
   - <a href="https://medium.com/the-saxifrage-school/1cc89b9de873">An Open School?</a>
   - <a href="http://theopencompany.net/pages/about-us">The Open [Products] Company</a>
-

--- a/_i18n/fr/join/index.md
+++ b/_i18n/fr/join/index.md
@@ -1,7 +1,7 @@
 <blockquote>
 
     &ldquo;Le monde a besoin de gens qui voient quelque chose qui doit
-    être fait et commencent à le faire, sans autorisation ou avis. Ils 
+    être fait et commencent à le faire, sans autorisation ou avis. Ils
     commencent juste à faire.&rdquo; <span>&mdash; Wendell Berry</span>
 
 </blockquote>
@@ -29,9 +29,4 @@ avec les informations suivantes:
 
 ### Cotisations
 
-Les cotisations sont libre, payer ce que vous voulez, <a
-href="https://gratipay.com/OpenCompany/">via Gratipay</a>.
-
-<div class="gratipay-widget">
-    <script data-gratipay-username="OpenCompany" src="//grtp.co/v1.js"></script>
-</div>
+Les cotisations sont libre, payer ce que vous voulez via [Liberapay](https://liberapay.com/opencompany/).

--- a/_i18n/pl/about/index.md
+++ b/_i18n/pl/about/index.md
@@ -39,18 +39,14 @@ OCI mieści się w [The Saxifrage School](http://www.saxifrageschool.org/),
 laboratorium szkolnictwa wyższego, działającego nad zmniejszeniem kosztów,
 sprzyjaniu przejrzystości, reorganizacją kampusu i pogodzeniu teorii z praktyką.
 
-Inicjatywa została założona [przez Gratipay](https://gratipay.com/OpenCompany/)
+Inicjatywa została założona przez Gratipay (dzisiaj [Liberapay](https://liberapay.com/))
 i nasze dyskusje prowadzimy używając przede wszystkim [GitHub](https://github.com/opencompany/www.opencompany.org/issues).
 Niektórych z nas można znaleźć na kanale IRC, na freenode: ##opencompany
 
 ### Finansowanie
 
-OCI jest finansowane w modelu „płać-ile-chcesz składki członkowskiej”, <a
-href="https://gratipay.com/OpenCompany/">przez Gratipay</a>.
-
-<div class="gratipay-widget">
-    <script data-gratipay-username="OpenCompany" src="//grtp.co/v1.js"></script>
-</div>
+OCI jest finansowane w modelu „płać-ile-chcesz składki członkowskiej"
+przez [Liberapay](https://liberapay.com/opencompany/).
 
 
 ### Dodatkowa lektura

--- a/_i18n/pl/join/index.md
+++ b/_i18n/pl/join/index.md
@@ -30,9 +30,4 @@ z tymi informacjami:
 
 ### Składki
 
-Składki członkowskie są w modelu płać-ile-chcesz, <a
-href="https://gratipay.com/OpenCompany/">przez Gratipay</a>.
-
-<div class="gratipay-widget">
-    <script data-gratipay-username="OpenCompany" src="//grtp.co/v1.js"></script>
-</div>
+Składki członkowskie są w modelu płać-ile-chcesz przez [Liberapay](https://liberapay.com/opencompany/).

--- a/css/main.008.css
+++ b/css/main.008.css
@@ -55,9 +55,6 @@ p {
     padding: 0 0 32pt;
     line-height: 32pt;
 }
-.gratipay-widget {
-    margin: 1em 2em;
-}
 
 blockquote {
     line-height: 150%;


### PR DESCRIPTION
The current site includes many pointers to Gratipay, which does not exist any more. I updated all pointers to Liberapay.